### PR TITLE
Feature/hst 54

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - develop
+      - feature/HST-54
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - feature/HST-54
+      - develop
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,9 +35,6 @@ jobs:
           VITE_AUTH0_REDIRECT_URI: ${{ secrets.VITE_AUTH0_REDIRECT_URI }}
         run: npm run build
 
-      - name: Copy index.html to 404.html
-        run: cp ./dist/index.html ./dist/404.html
-
       - name: Deploy with gh-pages
         run: |
             git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,9 @@ jobs:
           VITE_AUTH0_REDIRECT_URI: ${{ secrets.VITE_AUTH0_REDIRECT_URI }}
         run: npm run build
 
+      - name: Copy index.html to 404.html
+        run: cp ./dist/index.html ./dist/404.html
+
       - name: Deploy with gh-pages
         run: |
             git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git

--- a/public/404.html
+++ b/public/404.html
@@ -3,6 +3,10 @@
 
 <head>
     <meta http-equiv="refresh" content="0; url=./index.html" />
+    <script type="text/javascript">
+        var path = window.location.pathname;
+        window.location.replace('/repo_name/?redirect=' + encodeURIComponent(path));
+    </script>
 </head>
 
 <body></body>

--- a/public/404.html
+++ b/public/404.html
@@ -6,7 +6,6 @@
     <script type="text/javascript">
         window.onload = function () {
             var path = window.location.pathname;
-            console.log("Redirect path:", path);
             window.location.replace('/hst_web_ui/?redirect=' + encodeURIComponent(path));
         };
     </script>

--- a/public/404.html
+++ b/public/404.html
@@ -2,12 +2,13 @@
 <html>
 
 <head>
-    <meta charset="UTF-8">
-    <title>Redirecting...</title>
+    <meta http-equiv="refresh" content="0; url=./index.html" />
     <script type="text/javascript">
-        // Redirige cualquier URL hacia index.html preservando la ruta solicitada
-        var path = window.location.pathname + window.location.search;
-        window.location.replace('/hst_web_ui' + '/index.html?redirect=' + encodeURIComponent(path));
+        window.onload = function () {
+            var path = window.location.pathname;
+            console.log("Redirect path:", path);
+            window.location.replace('/hst_web_ui/?redirect=' + encodeURIComponent(path));
+        };
     </script>
 </head>
 

--- a/public/404.html
+++ b/public/404.html
@@ -2,10 +2,12 @@
 <html>
 
 <head>
-    <meta http-equiv="refresh" content="0; url=./index.html" />
+    <meta charset="UTF-8">
+    <title>Redirecting...</title>
     <script type="text/javascript">
+        // Redirige cualquier URL hacia index.html preservando la ruta solicitada
         var path = window.location.pathname + window.location.search;
-        window.location.replace('/repo_name/index.html?redirect=' + encodeURIComponent(path));
+        window.location.replace('/repo_name' + '/index.html?redirect=' + encodeURIComponent(path));
     </script>
 </head>
 

--- a/public/404.html
+++ b/public/404.html
@@ -4,11 +4,8 @@
 <head>
     <meta http-equiv="refresh" content="0; url=./index.html" />
     <script type="text/javascript">
-        window.onload = function () {
-            var path = window.location.pathname;
-            console.log("Redirect path:", path);
-            window.location.replace('/repo_name/?redirect=' + encodeURIComponent(path));
-        };
+        var path = window.location.pathname + window.location.search;
+        window.location.replace('/repo_name/index.html?redirect=' + encodeURIComponent(path));
     </script>
 </head>
 

--- a/public/404.html
+++ b/public/404.html
@@ -5,6 +5,7 @@
     <meta http-equiv="refresh" content="0; url=./index.html" />
     <script type="text/javascript">
         var path = window.location.pathname;
+        console.log(path);
         window.location.replace('/repo_name/?redirect=' + encodeURIComponent(path));
     </script>
 </head>

--- a/public/404.html
+++ b/public/404.html
@@ -4,9 +4,11 @@
 <head>
     <meta http-equiv="refresh" content="0; url=./index.html" />
     <script type="text/javascript">
-        var path = window.location.pathname;
-        console.log(path);
-        window.location.replace('/repo_name/?redirect=' + encodeURIComponent(path));
+        window.onload = function () {
+            var path = window.location.pathname;
+            console.log("Redirect path:", path);
+            window.location.replace('/repo_name/?redirect=' + encodeURIComponent(path));
+        };
     </script>
 </head>
 

--- a/public/404.html
+++ b/public/404.html
@@ -7,7 +7,7 @@
     <script type="text/javascript">
         // Redirige cualquier URL hacia index.html preservando la ruta solicitada
         var path = window.location.pathname + window.location.search;
-        window.location.replace('/repo_name' + '/index.html?redirect=' + encodeURIComponent(path));
+        window.location.replace('/hst_web_ui' + '/index.html?redirect=' + encodeURIComponent(path));
     </script>
 </head>
 

--- a/src/containers/AuthenticatedApp.tsx
+++ b/src/containers/AuthenticatedApp.tsx
@@ -44,13 +44,12 @@ const AuthenticatedApp = () => {
 
     useEffect(() => {
         const params = new URLSearchParams(window.location.search);
-        console.log(params)
         const redirectPath = params.get('redirect');
+
         if (redirectPath) {
-            // Remueve el prefijo "/hst_web_ui" de la ruta en caso de que esté presente
-            console.log(redirectPath)
+            // Removes the "/hst_web_ui" prefix from the path if present
+            // hst_web_ui is the GitHub repository name
             const sanitizedPath = redirectPath.replace(/^\/hst_web_ui/, '');
-            console.log(sanitizedPath)
             navigate(sanitizedPath, { replace: true });
         }
     }, [navigate]);

--- a/src/containers/AuthenticatedApp.tsx
+++ b/src/containers/AuthenticatedApp.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import { useDispatch } from "react-redux";
 import { AppDispatch } from "../redux/store.ts";
 import About from './About';
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes, useNavigate } from "react-router-dom";
 import Layout from "../components/Layout.tsx";
 import Tickets from "./Tickets.tsx";
 import Backoffice from './Backoffice.tsx';
@@ -17,6 +17,8 @@ const DIFFERENCE_DAYS_SEVEN = 7
 
 const AuthenticatedApp = () => {
     const dispatch = useDispatch<AppDispatch>();
+    const navigate = useNavigate();
+
 
     useEffect(() => {
         let networkMetadata = undefined
@@ -39,6 +41,18 @@ const AuthenticatedApp = () => {
 
 
     }, [dispatch]);
+
+    useEffect(() => {
+        const params = new URLSearchParams(window.location.search);
+        const redirectPath = params.get('redirect');
+        if (redirectPath) {
+            // Remueve el prefijo "/repo_name" de la ruta en caso de que esté presente
+            console.log(redirectPath)
+            const sanitizedPath = redirectPath.replace(/^\/repo_name/, '');
+            console.log(sanitizedPath)
+            navigate(sanitizedPath, { replace: true });
+        }
+    }, [navigate]);
 
     return (
         <ModalProvider>

--- a/src/containers/AuthenticatedApp.tsx
+++ b/src/containers/AuthenticatedApp.tsx
@@ -44,6 +44,7 @@ const AuthenticatedApp = () => {
 
     useEffect(() => {
         const params = new URLSearchParams(window.location.search);
+        console.log(params)
         const redirectPath = params.get('redirect');
         if (redirectPath) {
             // Remueve el prefijo "/repo_name" de la ruta en caso de que esté presente

--- a/src/containers/AuthenticatedApp.tsx
+++ b/src/containers/AuthenticatedApp.tsx
@@ -47,9 +47,9 @@ const AuthenticatedApp = () => {
         console.log(params)
         const redirectPath = params.get('redirect');
         if (redirectPath) {
-            // Remueve el prefijo "/repo_name" de la ruta en caso de que esté presente
+            // Remueve el prefijo "/hst_web_ui" de la ruta en caso de que esté presente
             console.log(redirectPath)
-            const sanitizedPath = redirectPath.replace(/^\/repo_name/, '');
+            const sanitizedPath = redirectPath.replace(/^\/hst_web_ui/, '');
             console.log(sanitizedPath)
             navigate(sanitizedPath, { replace: true });
         }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,6 +16,7 @@ const clientId = import.meta.env.VITE_AUTH0_CLIENT_ID;
 const devMode = import.meta.env.DEV;
 
 const redirect_uri = devMode ? window.location.origin : import.meta.env.VITE_AUTH0_REDIRECT_URI;
+console.log(redirect_uri)
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
@@ -27,7 +28,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       >
 
         <ThemeProvider theme={theme}>
-          <BrowserRouter>
+          <BrowserRouter basename='/hst_web_ui/'>
             <App />
           </BrowserRouter>
         </ThemeProvider>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -27,7 +27,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       >
 
         <ThemeProvider theme={theme}>
-          <BrowserRouter>
+          <BrowserRouter basename={redirect_uri}>
             <App />
           </BrowserRouter>
         </ThemeProvider>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,7 +16,6 @@ const clientId = import.meta.env.VITE_AUTH0_CLIENT_ID;
 const devMode = import.meta.env.DEV;
 
 const redirect_uri = devMode ? window.location.origin : import.meta.env.VITE_AUTH0_REDIRECT_URI;
-console.log(redirect_uri)
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
@@ -28,7 +27,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       >
 
         <ThemeProvider theme={theme}>
-          <BrowserRouter basename='/hst_web_ui/'>
+          <BrowserRouter basename={devMode ? '/' : '/hst_web_ui/'}>
             <App />
           </BrowserRouter>
         </ThemeProvider>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -27,7 +27,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       >
 
         <ThemeProvider theme={theme}>
-          <BrowserRouter basename={redirect_uri}>
+          <BrowserRouter>
             <App />
           </BrowserRouter>
         </ThemeProvider>


### PR DESCRIPTION
Fix reload page and add basename to `BrowserRouter`.

Previously, when a page was reloaded there was an 404 error. Now, pages can be reloaded with no error.